### PR TITLE
Shutdown postmark

### DIFF
--- a/docs/development/deployment/shutting-down.md
+++ b/docs/development/deployment/shutting-down.md
@@ -159,6 +159,6 @@ Find your website in the list, click the checkbox beside it and then click the *
 
 Once a site has been shut down, you should remove it from Postmark as it will be running periodic checks on the DNS DKIM record and will send emails complaining that it can't verify it.
 
-Simply go to the [Server](https://account.postmarkapp.com/servers) and select the server your are removing. Click on **Settings** and then **Delete server**.
+Simply go to [Servers](https://account.postmarkapp.com/servers) and select the one your are removing. Click on **Settings** and then **Delete server**.
 
 Then, go to [Sender Signatures](https://account.postmarkapp.com/signature_domains) and click the bin against the signature you are removing to delete it.


### PR DESCRIPTION
## Problem

When shutting down a site, I missed off a step at the end to remove the site from Postmark leading to email reminders about the DNS DKIM being missing.

## Solution

Added a new paragraph to the bottom as a reminder

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have prepared the deployment environment where relevant (i.e. ENV changes)